### PR TITLE
Add escape character to TeX in title

### DIFF
--- a/_posts/2021-05-29-gahlawat21a.md
+++ b/_posts/2021-05-29-gahlawat21a.md
@@ -1,5 +1,5 @@
 ---
-title: Contraction $\mathcalL_1$-Adaptive Control using Gaussian Processes
+title: Contraction $\\mathcal{L}_1$-Adaptive Control using Gaussian Processes
 abstract: " We present a control framework that enables safe simultaneous learning
   and control for systems subject to uncertainties. The two main constituents are
   contraction theory-based $\\mathcal{L}_1$-adaptive ($\\mathcal{CL}_1$) control and
@@ -15,7 +15,7 @@ publisher: PMLR
 issn: 2640-3498
 id: gahlawat21a
 month: 0
-tex_title: Contraction $\\mathcal{L}_1$-Adaptive Control using Gaussian Processes
+tex_title: Contraction $\mathcal{L}_1$-Adaptive Control using Gaussian Processes
 firstpage: 1027
 lastpage: 1040
 page: 1027-1040

--- a/_posts/2021-05-29-gahlawat21a.md
+++ b/_posts/2021-05-29-gahlawat21a.md
@@ -15,7 +15,7 @@ publisher: PMLR
 issn: 2640-3498
 id: gahlawat21a
 month: 0
-tex_title: Contraction $\mathcal{L}_1$-Adaptive Control using Gaussian Processes
+tex_title: Contraction $\\mathcal{L}_1$-Adaptive Control using Gaussian Processes
 firstpage: 1027
 lastpage: 1040
 page: 1027-1040


### PR DESCRIPTION
The math in the paper title does not display properly: https://proceedings.mlr.press/v144/gahlawat21a.html because the title was not correctly escaped. This PR adds an escape character to the title.