### PR TITLE
Remove math formatting from title

### DIFF
--- a/_posts/2021-05-29-gahlawat21a.md
+++ b/_posts/2021-05-29-gahlawat21a.md
@@ -1,5 +1,5 @@
 ---
-title: Contraction $\\mathcal{L}_1$-Adaptive Control using Gaussian Processes
+title: Contraction L1-Adaptive Control using Gaussian Processes
 abstract: " We present a control framework that enables safe simultaneous learning
   and control for systems subject to uncertainties. The two main constituents are
   contraction theory-based $\\mathcal{L}_1$-adaptive ($\\mathcal{CL}_1$) control and
@@ -15,7 +15,7 @@ publisher: PMLR
 issn: 2640-3498
 id: gahlawat21a
 month: 0
-tex_title: Contraction $\mathcal{L}_1$-Adaptive Control using Gaussian Processes
+tex_title: Contraction L1-Adaptive Control using Gaussian Processes
 firstpage: 1027
 lastpage: 1040
 page: 1027-1040


### PR DESCRIPTION
In a previous PR (#4), I added escapes to a TeX-formatted term in the title but it doesn't seem to have fixed the issue: https://proceedings.mlr.press/v144/gahlawat21a.html. This PR removes the formatting altogether.