### PR TITLE
request to add an erratum to the abstract

### DIFF
--- a/_posts/2021-05-29-hanson21a.md
+++ b/_posts/2021-05-29-hanson21a.md
@@ -9,7 +9,9 @@ abstract: 'We consider the following learning problem: Given sample pairs of inp
   learning problem in familiar system-theoretic language and derive quantitative guarantees
   on the sup-norm risk of the learned model in terms of the number of neurons, the
   sample size, the number of derivatives being matched, and the regularity properties
-  of the inputs, the outputs, and the unknown i/o map.'
+  of the inputs, the outputs, and the unknown i/o map.
+  
+  Erratum: There is an error in Theorem 4, which has propagated to the main result of the paper (Theorem 5). The corrected version has been posted to arXiv: https://arxiv.org/abs/2011.09573.'
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 publisher: PMLR


### PR DESCRIPTION
Erratum: There is an error in Theorem 4, which has propagated to the main result of the paper (Theorem 5). The corrected version has been posted to arXiv: https://arxiv.org/abs/2011.09573.