### PR TITLE
Update 2021-05-29-bunning21a.md

### DIFF
--- a/_posts/2021-05-29-bunning21a.md
+++ b/_posts/2021-05-29-bunning21a.md
@@ -26,8 +26,8 @@ lastpage: 262
 page: 251-262
 order: 251
 cycles: false
-bibtex_author: B\"unning, Felix and Schalbetter, Adrian and Aboudonia, Ahmed and de
-  Badyn, Mathias Hudoba and Heer, Philipp and Lygeros, John
+bibtex_author: B\"unning, Felix and Schalbetter, Adrian and Aboudonia, Ahmed and Hudoba de
+  Badyn, Mathias and Heer, Philipp and Lygeros, John
 author:
 - given: Felix
   family: Bünning
@@ -35,9 +35,8 @@ author:
   family: Schalbetter
 - given: Ahmed
   family: Aboudonia
-- given: Mathias Hudoba
-  family: Badyn
-  prefix: de
+- given: Mathias
+  family: Hudoba de Badyn
 - given: Philipp
   family: Heer
 - given: John


### PR DESCRIPTION
Fixed author name metadata. Author "Mathias Hudoba de Badyn" has the last name "Hudoba de Badyn" and first name "Mathias". The metadata was incorrectly listed as "Badyn, Mathias Hudoba de". This was corrected in both the bibtex_author line, and the metadata for the html page.